### PR TITLE
FIX Tree components

### DIFF
--- a/data_structures/src/FlatTree.jsx
+++ b/data_structures/src/FlatTree.jsx
@@ -24,10 +24,10 @@ const MenuItem = ({id, items}) => {
 
   if (item.children) {
     return (
-      <>
-        <li>{item.name}</li>
+      <li>
+        {item.name}
         <NestedMenu key={id} ids={item.children} items={items} />
-      </>
+      </li>
     );
   }
 

--- a/data_structures/src/Tree.jsx
+++ b/data_structures/src/Tree.jsx
@@ -50,19 +50,20 @@ const menu = [
   },
 ];
 
-const createMenu = (menu) => {
-  return menu.map(({name, children}, idx) => {
-    return (
-      <>
-        <li key={idx}>{name}</li>
-
-        {children && <ul>{createMenu(children)}</ul>}
-      </>
-    );
-  });
+const NestedMenu = ({menu}) => {
+  return (
+    <ul>
+      {menu.map(({name, children}, idx) => (
+        <li key={idx}>
+          {name}
+          {children && <NestedMenu menu={children} />}
+        </li>
+      ))}
+    </ul>
+  );
 };
 
-const RootMenu = () => <ul>{createMenu(menu)}</ul>;
+const RootMenu = () => <NestedMenu menu={menu} />;
 
 export default function Tree() {
   return <RootMenu />;


### PR DESCRIPTION
Componente Tree apresentava warnings devido a falta de key em certos elementos filhos.

A implementação foi melhorada para remover esses erros, assim como torná-la mais adequada ao framework react.

Já para o componente FlatTree, foi arrumado o "sub componente" MenuItem